### PR TITLE
Jitpack -> Maven, Kotlin/Compose version update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@
 .externalNativeBuild
 .cxx
 local.properties
+gradle.properties
 secring.gpg
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@
 .externalNativeBuild
 .cxx
 local.properties
+secring.gpg
 *~

--- a/README.md
+++ b/README.md
@@ -25,31 +25,15 @@ A Jetpack Compose library for creating beautiful circular audio visualizations i
 
 ## Installation
 
-### Step 1. Add JitPack repository
-
-Add it in your root `settings.gradle.kts`:
-
-```kotlin
-dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-    repositories {
-        mavenCentral()
-        maven { url = uri("https://jitpack.io") }
-    }
-}
-```
-
-### Step 2. Add the dependency
-
-Add it in your module `build.gradle.kts`:
+Add the dependency in your module `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("com.github.miller198:ComposeCircleAudioVisualizer:1.0.2")
+    implementation("io.github.miller198:ComposeCircleAudioVisualizer:1.1.0")
 }
 ```
 
-### Step 3. Add RECORD_AUDIO permission
+### Add RECORD_AUDIO permission
 
 Add the following permission to your `AndroidManifest.xml`:
 
@@ -58,6 +42,37 @@ Add the following permission to your `AndroidManifest.xml`:
 ```
 
 > **Note**: You must request this permission at runtime for Android 6.0 (API 23) and above.
+
+---
+
+## 📢 Migration to Maven Central
+
+Since version **1.1.0**, this library is published to **Maven Central**.
+
+> **Note**: Versions 1.0.x are still available on JitPack.
+
+### For existing users (migrating from JitPack)
+
+**1. Remove JitPack repository** from your `settings.gradle.kts`:
+
+```diff
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+-       maven { url = uri("https://jitpack.io") }
+    }
+}
+```
+
+**2. Update the dependency** in your module `build.gradle.kts`:
+
+```diff
+dependencies {
+-   implementation("com.github.miller198:ComposeCircleAudioVisualizer:1.0.2")
++   implementation("io.github.miller198:ComposeCircleAudioVisualizer:1.1.0")
+}
+```
 
 ---
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,6 @@ android {
 }
 
 dependencies {
-    implementation(project(":audio_visualizer"))
-
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
@@ -62,4 +60,6 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.inject)
+
+    implementation(libs.composecircleaudiovisualizer)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.compose.compiler)
 }
 
 android {
@@ -32,9 +33,6 @@ android {
     }
     buildFeatures {
         compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.14"
     }
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
     <application
-        android:name=".MyApplication"
+        android:name=".SampleApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/miller198/audiovisualizsample/SampleApplication.kt
+++ b/app/src/main/java/com/miller198/audiovisualizsample/SampleApplication.kt
@@ -4,7 +4,7 @@ import android.app.Application
 import com.miller198.audiovisualizsample.data.SettingRepositoryImpl
 import com.miller198.audiovisualizsample.domain.SettingRepository
 
-class MyApplication : Application() {
+class SampleApplication : Application() {
     val settingRepository: SettingRepository by lazy {
         SettingRepositoryImpl(this)
     }

--- a/app/src/main/java/com/miller198/audiovisualizsample/presentation/screen/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/miller198/audiovisualizsample/presentation/screen/setting/SettingViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
-import com.miller198.audiovisualizsample.MyApplication
+import com.miller198.audiovisualizsample.SampleApplication
 import com.miller198.audiovisualizsample.domain.PlayerPreference
 import com.miller198.audiovisualizsample.domain.SettingRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -17,7 +17,7 @@ import javax.inject.Inject
 object SettingViewModelFactory {
     val Factory = viewModelFactory {
         initializer {
-            val app = (this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY] as MyApplication)
+            val app = (this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY] as SampleApplication)
 
             SettingViewModel(app.settingRepository)
         }

--- a/audio_visualizer/build.gradle.kts
+++ b/audio_visualizer/build.gradle.kts
@@ -1,18 +1,47 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.compose.compiler)
     alias(libs.plugins.maven.publish)
+    alias(libs.plugins.vanniktech.maven.publish)
 }
 
-afterEvaluate {
-    publishing {
-        publications {
-            create<MavenPublication>("release") {
-                from(components["release"])
-                groupId = "com.github.miller198"
-                artifactId = "ComposeCircleAudioVisualizer"
-                version = "1.0.0"
+mavenPublishing {
+    publishToMavenCentral()
+    signAllPublications()
+
+    coordinates(
+        groupId = "io.github.miller198",
+        artifactId = "ComposeCircleAudioVisualizer", // 라이브러리 이름
+        version = libs.versions.libraryVersion.get() // 라이브러리 버전 입력
+    )
+
+    pom {
+        name = "Compose Circular Audio Visualizer"
+        description = "A Jetpack Compose library for audio visualization"
+        inceptionYear = "2026"
+        url = "https://github.com/miller198/ComposeCircleAudioVisualizer"
+
+        licenses {
+            license {
+                name = "The Apache License, Version 2.0"
+                url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                description = "http://www.apache.org/licenses/LICENSE-2.0.txt"
             }
+        }
+
+        developers {
+            developer {
+                id = "miller198"
+                name = "miller198"
+                url = "https://github.com/miller198"
+            }
+        }
+
+        scm {
+            url = "https://github.com/miller198/ComposeCircleAudioVisualizer"
+            connection = "scm:git:git://github.com/miller198/ComposeCircleAudioVisualizer.git"
+            developerConnection = "scm:git:ssh://git@github.com/miller198/ComposeCircleAudioVisualizer.git"
         }
     }
 }
@@ -40,9 +69,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.14"
     }
     kotlinOptions {
         jvmTarget = "17"

--- a/audio_visualizer/src/main/java/com/miller198/audiovisualizer/BaseVisualizer.kt
+++ b/audio_visualizer/src/main/java/com/miller198/audiovisualizer/BaseVisualizer.kt
@@ -35,7 +35,7 @@ class BaseVisualizer {
 
         // Validate capture size and fallback to max size if needed
         visualizer?.captureSize =
-            if (!isPowerOfTwo(captureSize) || !isValidCaptureSize(captureSize)) {
+            if (!captureSize.isPowerOfTwo() || !captureSize.isValidCaptureSize()) {
                 Visualizer.getCaptureSizeRange()[1].also {
                     Log.w("BaseVisualizer", "Invalid capture size, fallback to max: $it")
                 }
@@ -99,15 +99,15 @@ class BaseVisualizer {
     /**
      * Checks whether the provided [captureSize] is a power of two.
      */
-    private fun isPowerOfTwo(captureSize: Int): Boolean {
-        return captureSize > 0 && (captureSize and (captureSize - 1)) == 0
+    private fun Int.isPowerOfTwo(): Boolean {
+        return this > 0 && (this and (this - 1)) == 0
     }
 
     /**
      * Checks whether the provided [captureSize] is within the valid range supported by [Visualizer].
      */
-    private fun isValidCaptureSize(captureSize: Int): Boolean {
+    private fun Int.isValidCaptureSize(): Boolean {
         val range = Visualizer.getCaptureSizeRange()
-        return captureSize in range[0]..range[1]
+        return this in range[0]..range[1]
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,6 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.compose.compiler) apply false
+    alias(libs.plugins.vanniktech.maven.publish) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 libraryVersion = "1.1.0"
+composecircleaudiovisualizer = "1.1.0"
 agp = "8.13.0"
 kotlin = "2.0.21"
 coreKtx = "1.13.1"
@@ -20,6 +21,7 @@ vanniktechMavenPublish = "0.36.0"
 media3Ui = "1.5.1"
 
 [libraries]
+composecircleaudiovisualizer = { module = "io.github.miller198:ComposeCircleAudioVisualizer", version.ref = "composecircleaudiovisualizer" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,22 +1,21 @@
 [versions]
-agp = "8.7.0"
-kotlin = "1.9.24"
+libraryVersion = "1.1.0"
+agp = "8.13.0"
+kotlin = "2.0.21"
 coreKtx = "1.13.1"
 inject = "1"
 androidx-lifecycle = "2.8.3"
 androidx-datastore-preferences = "1.1.1"
 junit = "4.13.2"
-junitVersion = "1.2.1"
-espressoCore = "3.6.1"
+junitVersion = "1.1.5"
+espressoCore = "3.5.0"
 lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.9.3"
-compose-runtime-android = "1.7.6"
-composeBom = "2024.04.01"
+composeBom = "2025.04.00"
 appcompat = "1.7.0"
 material = "1.12.0"
-composeMaterial3 = "1.3.1"
-composeMaterialIconsExtended = "1.7.8"
 lifecycleRuntimeComposeAndroid = "2.8.7"
+vanniktechMavenPublish = "0.36.0"
 # Media3
 media3Ui = "1.5.1"
 
@@ -28,7 +27,7 @@ androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-co
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
-compose-runtime-android = { group = "androidx.compose.runtime", name = "runtime-android", version.ref = "compose-runtime-android" }
+compose-runtime-android = { group = "androidx.compose.runtime", name = "runtime-android" }
 androidx-lifecycle-runtime-compose-android = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose-android", version.ref = "lifecycleRuntimeComposeAndroid" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 
@@ -38,10 +37,10 @@ androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
-androidx-material3 = { group = "androidx.compose.material3", name = "material3", version = "composeMaterial3" }
+androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
-compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "composeMaterialIconsExtended" }
+compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
 
 # Data
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "androidx-datastore-preferences" }
@@ -56,7 +55,9 @@ androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", versi
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version.ref = "agp" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 maven-publish = { id = "maven-publish" }
+vanniktech-maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "vanniktechMavenPublish" }
 
 [bundles]
 compose = [

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Mar 26 19:14:20 KST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## 🛠 Key Changes
- **Publishing:** Migrated from JitPack to Maven Central (`io.github.miller198`).
- **Kotlin:** Updated from `1.9.24` to `2.0.21` (K2 Compiler support).
- **Compose BOM:** Updated from `2024.04.01` to `2025.04.00`.
- **AGP:** Updated Android Gradle Plugin from `8.7.0` to `8.13.0`.